### PR TITLE
Use DC source to relate Folder on DIP import

### DIFF
--- a/scope/parsemets.py
+++ b/scope/parsemets.py
@@ -182,14 +182,12 @@ class METS(object):
         dc_data = self._parse_dc()
         if dc_data:
             logger.info("Updating DIP Dublin Core metadata")
-            # The `isPartOf` value is only used to find a related Collection,
+            # The `source` value is also used to find a related Collection,
             # until slugs are implemented the relation is made using the DC
             # identifier from the collections, which is not an unique field.
-            collection_id = dc_data.pop("isPartOf", None)
+            collection_id = dc_data.get("source", None)
             if collection_id:
                 try:
-                    # Remove AIC identifier if present
-                    collection_id = collection_id.replace("AIC#", "")
                     dip.collection = Collection.objects.get(
                         dc__identifier=collection_id
                     )
@@ -316,7 +314,6 @@ class METS(object):
             "language": "",
             "coverage": "",
             "rights": "",
-            "isPartOf": "",
         }
         for elem in dc_xml:
             key = str(elem.tag)


### PR DESCRIPTION
Use the `source` field instead of the `isParOf` field from the Dublin
Core metadata related to the DIP in the METS file to find a parent
Collection for the the created Folder on the DIP import process.

Refs #175.