### PR TITLE
Pin Elasticsearch client library to 7.13.0 to avoid UnsupportedProductError

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,7 @@ django-modeltranslation==0.16.1
 django-npm==1.0.0
 djangorestframework==3.12.2
 django-widget-tweaks==1.4.8
+elasticsearch==7.13.0
 elasticsearch-dsl==7.3.0 # pyup: <8.0
 envparse==0.2.0
 gevent==21.1.2


### PR DESCRIPTION
Newer versions of the Elasticsearch Python client library throw an `UnsupportedProductError` when used with the "oss" build following Elastic's recent [licensing changes](https://www.elastic.co/pricing/faq/licensing). This commit pins the client library to `elasticsearch==7.13.0` per the advice at https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883319286.

Related to https://github.com/CCA-Public/scope/issues/192