### PR TITLE
Remove set -ex from RUN commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,17 @@ RUN set -ex \
 
 COPY requirements /build
 
-RUN set -ex  pip install --no-cache-dir -r /build/development.txt
+RUN pip install --no-cache-dir -r /build/development.txt
 
 COPY package.json package-lock.json /build/
 
-RUN set -ex npm install --prefix /build
+RUN npm install --prefix /build
 
 COPY . /src
 
 WORKDIR /src
 
-RUN set -xe mv /build/node_modules ./
+RUN mv /build/node_modules ./
 
 EXPOSE 8000
 


### PR DESCRIPTION
Connected to #236 

After switching base images, it is necessary to remove `set -ex` from the RUN commands in the Dockerfile. Following this change, the Dockerfile builds correctly again.